### PR TITLE
Fix `Grid#clear()` causing mod by zero errors when used again

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -35,6 +35,8 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
     let mut grid = supergrid::Grid::new(2048, opt.cell_size);
+    grid.clear(); // Ensure clearing grid doesn't make it unusable later on.
+
     println!("Setup:");
     println!(
         "\tArena width:         {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,13 +45,15 @@ struct Map(ArrayVec<(u32, u32), FIXED_SIZE>);
 #[derive(Debug, Clone)]
 pub struct Table<T: Default + Clone> {
     entries: Vec<T>,
+    cached_entries_capacity: usize
 }
 
 impl<T: Default + Clone> Table<T> {
     /// Create a new table with `size` entries.
     pub fn new(size: usize) -> Self {
-        let entries = vec![T::default(); (size * 1000).next_power_of_two() + 1];
-        Self { entries }
+        let cached_entries_capacity = (size * 1000).next_power_of_two() + 1;
+        let entries = vec![T::default(); cached_entries_capacity];
+        Self { entries, cached_entries_capacity }
     }
 
     /// Get entry number.
@@ -95,6 +97,7 @@ impl<T: Default + Clone> Table<T> {
     /// Clear the table.
     pub fn clear(&mut self) {
         self.entries.clear();
+        self.entries.resize(self.cached_entries_capacity, T::default());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,8 @@ impl Grid {
             let index = cell.0.iter().position(|x| (*x & !(1 << 31)) == id).unwrap();
             cell.0.remove(index);
         }
+
+        self.maps.get_scalar_mut(id).0.clear();
     }
 
     /// Retrieve entities in a region.


### PR DESCRIPTION
```rs
let mut grid = supergrid::Grid::new(2048, opt.cell_size);
grid.clear();
grid.insert(&(supergrid::Entity { id: 2, x: 10, y: 10, width: 10, height: 10 } ));
```

This snippet throws a mod by zero error. When clearing the grid, the internal hashtables are cleared, but this also results in the lengths of them being zero. When calling `.index()`, the grid performs a mod by the length of the vector (which is zero after cleared). To fix this, clearing the hashtable will also resize the vector to preserve the same length.